### PR TITLE
Test Helper Refactor Again

### DIFF
--- a/homelab_backend/src/db/mod.rs
+++ b/homelab_backend/src/db/mod.rs
@@ -13,7 +13,7 @@ pub mod db_setup;
 pub fn str_to_object_id(object_str: &str) -> Result<ObjectId, Error> {
     match ObjectId::parse_str(object_str) {
         Ok(object_id) => Ok(object_id),
-        Err(_) => Err(Error::custom("Failed to construct ObjectId")),
+        Err(_) => Err(Error::custom("Failed to construct ObjectId".to_string())),
     }
 }
 

--- a/homelab_backend/src/error_handler.rs
+++ b/homelab_backend/src/error_handler.rs
@@ -1,4 +1,5 @@
 use mongodb::error::{ErrorKind, WriteFailure};
+use std::sync::Arc;
 
 use crate::api::return_data::ReturnData;
 
@@ -10,6 +11,7 @@ pub enum DbError {
     EmptyDbExpression(&'static str, String),
     BadId,
     AuthFailure,
+    CustomMongoFailure(String),
     UnhandledException(String),
 }
 
@@ -30,6 +32,14 @@ impl From<mongodb::error::Error> for DbError {
                 },
                 _ => DbError::UnhandledException("Unhandled error while writing data".to_owned()),
             },
+            ErrorKind::Custom(custom_message) => {
+                if let Ok(custom_error_message) = custom_message.downcast::<String>() {
+                    if let Some(owned_error_message) = Arc::into_inner(custom_error_message) {
+                        return DbError::CustomMongoFailure(owned_error_message);
+                    }
+                }
+                DbError::UnhandledException("Unhandled failure while resolving custom MongoDB error".to_string())
+            }
             _ => DbError::UnhandledException("Unhandled failure".to_owned()),
         }
     }
@@ -48,6 +58,7 @@ impl<T> From<DbError> for ReturnData<T> {
             }
             DbError::BadId => ReturnData::not_found("The provided ID was not valid".to_owned()),
             DbError::AuthFailure => ReturnData::unauthorized("Auth failure while reading database".to_owned()),
+            DbError::CustomMongoFailure(custom_message) => ReturnData::bad_request(custom_message),
             DbError::UnhandledException(error_while) => {
                 ReturnData::internal_error(format!("Unhandled exception when making a database request: {error_while}"))
             }

--- a/homelab_backend/src/models/chat/message_db.rs
+++ b/homelab_backend/src/models/chat/message_db.rs
@@ -60,7 +60,7 @@ async fn execute_chat_message_transaction(
     let filter_doc = doc! {"_id": Bson::ObjectId(channel_id)};
     let channel = match channel_collection.find_one(filter_doc).session(&mut *session).await? {
         Some(channel) => channel,
-        None => return Err(MongoError::custom("Failed to find a chat channel with the given ID")),
+        None => return Err(MongoError::custom("Failed to find a chat channel with the given ID".to_string())),
     };
 
     // Create a message
@@ -75,7 +75,7 @@ async fn execute_chat_message_transaction(
     let message_id = insert_result
         .inserted_id
         .as_object_id()
-        .ok_or(MongoError::custom("Failed to parse an insertion ID to ObjectID"))?;
+        .ok_or(MongoError::custom("Failed to parse an insertion ID to ObjectID".to_string()))?;
     channel_collection
         .update_one(channel_filter_doc, channel_update)
         .session(&mut *session)
@@ -85,7 +85,7 @@ async fn execute_chat_message_transaction(
         // Emergency safety valve to stop an infinite hang if mongo behaves strangely
         loop_counter += 1;
         if loop_counter > 500 {
-            return Err(MongoError::custom("Exceeded retries"));
+            return Err(MongoError::custom("Exceeded retries".to_string()));
         }
         let result = session.commit_transaction().await;
         if let Err(error) = result {

--- a/homelab_backend/src/testing/chat_testing.rs
+++ b/homelab_backend/src/testing/chat_testing.rs
@@ -5,7 +5,6 @@ mod chat_testing {
         TestHelper, FAKE_MONGO_ID,
     };
     use hyper::StatusCode;
-    use std::net::SocketAddr;
 
     use crate::models::chat::{
         chat_channel::{ChannelType, ReturnChannel},
@@ -18,9 +17,6 @@ mod chat_testing {
         subscribe_to_channel, unsubscribe_from_channel,
     };
 
-    use axum::body::Body;
-    use hyper_util::client::legacy::{connect::HttpConnector, Client};
-
     struct ChatHelper {
         users: Vec<ReturnUser>,
         tokens: Vec<String>,
@@ -28,7 +24,7 @@ mod chat_testing {
     }
 
     impl ChatHelper {
-        pub async fn setup_chat(client: &Client<HttpConnector, Body>, addr: &SocketAddr, user_and_channel_count: usize) -> Self {
+        pub async fn setup_chat(test_helper: &TestHelper, user_and_channel_count: usize) -> Self {
             let mut users: Vec<ReturnUser> = Vec::new();
             let mut tokens: Vec<String> = Vec::new();
             let mut channels: Vec<ReturnChannel> = Vec::new();
@@ -39,8 +35,8 @@ mod chat_testing {
                 // TODO: Client and addr are being passed all over the place, and here it's causing a needless import. Should
                 //       bundle this into an actual testing struct
                 // Create a user, get the user and a token for the user
-                let token = create_user(client, username.as_str(), password.as_str(), addr).await.unwrap();
-                let user = get_user_me(client, token.as_str(), addr).await.unwrap();
+                let token = create_user(test_helper, username.as_str(), password.as_str()).await.unwrap();
+                let user = get_user_me(test_helper, token.as_str()).await.unwrap();
 
                 // Create a channel for the user
                 let data = CreateChannelSchema {
@@ -48,7 +44,7 @@ mod chat_testing {
                     channel_type: 0,
                     slug: format!("channel-{}", n),
                 };
-                let channel = create_chat_channel(client, addr, token.as_str(), &data)
+                let channel = create_chat_channel(test_helper, token.as_str(), &data)
                     .await
                     .expect("Failed to create a chat channel");
 
@@ -63,8 +59,6 @@ mod chat_testing {
     #[tokio::test]
     async fn chat_channels_crud() {
         let helper = TestHelper::init().await;
-        let client = &helper.client;
-        let addr = &helper.address;
 
         let username = "foo";
         let password = "foo";
@@ -73,12 +67,12 @@ mod chat_testing {
         let password_two = "second";
 
         // Create users
-        let token = create_user(client, username, password, addr).await.unwrap();
-        let second_token = create_user(client, username_two, password_two, addr).await.unwrap();
+        let token = create_user(&helper, username, password).await.unwrap();
+        let second_token = create_user(&helper, username_two, password_two).await.unwrap();
 
         // Get our user so we have their id
-        let user = get_user_me(client, token.as_str(), addr).await.unwrap();
-        let user_two = get_user_me(client, second_token.as_str(), addr).await.unwrap();
+        let user = get_user_me(&helper, token.as_str()).await.unwrap();
+        let user_two = get_user_me(&helper, second_token.as_str()).await.unwrap();
 
         // Create a channel without a name
         let data = CreateChannelSchema {
@@ -86,7 +80,7 @@ mod chat_testing {
             channel_type: 0,
             slug: "test_channel".to_string(),
         };
-        let first_channel = create_chat_channel(client, addr, token.as_str(), &data)
+        let first_channel = create_chat_channel(&helper, token.as_str(), &data)
             .await
             .expect("Failed to create a chat channel");
         assert_eq!(first_channel.name, None);
@@ -103,14 +97,14 @@ mod chat_testing {
             channel_type: 1,
             slug: "second_channel".to_string(),
         };
-        let second_channel = create_chat_channel(client, addr, token.as_str(), &data_two)
+        let second_channel = create_chat_channel(&helper, token.as_str(), &data_two)
             .await
             .expect("Failed to create a chat channel with a name");
         assert_eq!(second_channel.name, Some("My Channel".to_string()));
         assert_eq!(second_channel.channel_type, ChannelType::Group);
 
         // Try to create a channel with a duplicate slug for a user, which should fail
-        match create_chat_channel(client, addr, token.as_str(), &data).await {
+        match create_chat_channel(&helper, token.as_str(), &data).await {
             Ok(_) => panic!("Creating a chat channel with a duplicate slug for a user should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -120,7 +114,7 @@ mod chat_testing {
         };
 
         // Create a channel with a duplicate slug, but for a new user which should be fine
-        let third_channel = create_chat_channel(client, addr, second_token.as_str(), &data)
+        let third_channel = create_chat_channel(&helper, second_token.as_str(), &data)
             .await
             .expect("Failed to create a chat channel");
         assert_eq!(third_channel.slug.as_str(), "test_channel");
@@ -128,7 +122,7 @@ mod chat_testing {
         assert_eq!(third_channel.owner_id, user_two.id.as_str());
 
         // Try to subscribe to a channel that doesn't exist
-        match subscribe_to_channel(client, addr, token.as_str(), token.as_str()).await {
+        match subscribe_to_channel(&helper, token.as_str(), token.as_str()).await {
             Ok(_) => panic!("Subscribing to a non-existent channel should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -138,26 +132,26 @@ mod chat_testing {
         };
 
         // Try to get a channel that does not exist
-        match get_channel_by_id(client, addr, token.as_str(), FAKE_MONGO_ID).await {
+        match get_channel_by_id(&helper, token.as_str(), FAKE_MONGO_ID).await {
             Ok(_) => panic!("Getting a channel by a non-existent ID should fail"),
             Err((status_code, _msg)) => assert_eq!(status_code, StatusCode::NOT_FOUND, "Getting a channel by a non-existent ID should 404"),
         };
 
         // Subscribe to a channel
-        let subscribed_channel = subscribe_to_channel(client, addr, token.as_str(), third_channel._id.as_str())
+        let subscribed_channel = subscribe_to_channel(&helper, token.as_str(), third_channel._id.as_str())
             .await
             .expect("Failed to subscribe to another users chat channel");
         assert!(subscribed_channel.subscribers.contains(&user.clone().into()));
 
         // Get a chat channel, verify that the subscriber list looks correct
-        let get_channel = get_channel_by_id(client, addr, token.as_str(), first_channel._id.as_str())
+        let get_channel = get_channel_by_id(&helper, token.as_str(), first_channel._id.as_str())
             .await
             .expect("Failed to get a chat channel by ID");
         assert_eq!(get_channel._id.as_str(), first_channel._id.as_str());
         assert!(get_channel.subscribers.contains(&user.clone().into()));
 
         // Try to subscribe to a channel the user is already subscribed to
-        match subscribe_to_channel(client, addr, token.as_str(), first_channel._id.as_str()).await {
+        match subscribe_to_channel(&helper, token.as_str(), first_channel._id.as_str()).await {
             Ok(_) => panic!("Subscribing to a channel already subscribed to should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -167,7 +161,7 @@ mod chat_testing {
         };
 
         // Try to unsubscribe from a channel that doesn't exist
-        match unsubscribe_from_channel(client, addr, token.as_str(), token.as_str()).await {
+        match unsubscribe_from_channel(&helper, token.as_str(), token.as_str()).await {
             Ok(_) => panic!("Unsubscribing from a non-existent channel should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -177,13 +171,13 @@ mod chat_testing {
         };
 
         // Unsubscribe from a channel
-        let unsubscribed_channel = unsubscribe_from_channel(client, addr, token.as_str(), third_channel._id.as_str())
+        let unsubscribed_channel = unsubscribe_from_channel(&helper, token.as_str(), third_channel._id.as_str())
             .await
             .expect("Failed to unsubscribe from another users chat channel");
         assert!(!unsubscribed_channel.subscribers.contains(&user.clone().into()));
 
         // Try to unsubscribe from a channel the user is not in
-        match unsubscribe_from_channel(client, addr, token.as_str(), third_channel._id.as_str()).await {
+        match unsubscribe_from_channel(&helper, token.as_str(), third_channel._id.as_str()).await {
             Ok(_) => panic!("Unsubscribing from a channel a user is not in should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -193,19 +187,19 @@ mod chat_testing {
         };
 
         // Try to unsubscribe from an owned channel, which should fail
-        match unsubscribe_from_channel(client, addr, token.as_str(), first_channel._id.as_str()).await {
+        match unsubscribe_from_channel(&helper, token.as_str(), first_channel._id.as_str()).await {
             Ok(_) => panic!("Unsubscribing from an owned channel should fail"),
             Err((status_code, _msg)) => assert_eq!(status_code, StatusCode::NOT_FOUND, "Unsubscribing from an owned channel should 404"),
         };
 
         // List all channels with no query params
-        let all_channels = list_channels(client, addr, token.as_str(), "")
+        let all_channels = list_channels(&helper, token.as_str(), "")
             .await
             .expect("Failed to list all chat channels");
         assert_eq!(all_channels.len(), 3);
 
         // List only my channels
-        let my_channels = list_channels(client, addr, token.as_str(), "?my_channels=true")
+        let my_channels = list_channels(&helper, token.as_str(), "?my_channels=true")
             .await
             .expect("Failed to list channels filtered to ones owned by the requester");
         assert_eq!(my_channels.len(), 2);
@@ -213,14 +207,14 @@ mod chat_testing {
         assert_eq!(my_channels[1].owner_id, user.id);
 
         // List only other channels
-        let other_channels = list_channels(client, addr, token.as_str(), "?my_channels=false")
+        let other_channels = list_channels(&helper, token.as_str(), "?my_channels=false")
             .await
             .expect("Failed to list channels owned by users other than the requester");
         assert_eq!(other_channels.len(), 1);
         assert_eq!(other_channels[0].owner_id, user_two.id);
 
         // List subscribed channels, include "my_channels" here as the user is currently only subscribed to their own channels
-        let subscribed = list_channels(client, addr, token.as_str(), "?subscribed=true&my_channels=true")
+        let subscribed = list_channels(&helper, token.as_str(), "?subscribed=true&my_channels=true")
             .await
             .expect("Failed to list channels the requester subscribes to");
         assert_eq!(subscribed.len(), 2);
@@ -228,7 +222,7 @@ mod chat_testing {
         assert!(subscribed[1].subscribers.contains(&user.clone().into()));
 
         // List unsubscribed channels
-        let unsubscribed = list_channels(client, addr, token.as_str(), "?subscribed=false")
+        let unsubscribed = list_channels(&helper, token.as_str(), "?subscribed=false")
             .await
             .expect("Failed to list channels the requester is not subscribed to");
         assert_eq!(unsubscribed.len(), 1);
@@ -241,10 +235,9 @@ mod chat_testing {
     #[tokio::test]
     async fn chat_messages_basic() {
         let helper = TestHelper::init().await;
-        let client = &helper.client;
         let addr = &helper.address;
 
-        let chat_helper = ChatHelper::setup_chat(client, addr, 2).await;
+        let chat_helper = ChatHelper::setup_chat(&helper, 2).await;
         let token = chat_helper.tokens[0].as_str();
         let second_token = chat_helper.tokens[1].as_str();
         let user_one_id = chat_helper.users[0].id.as_str();
@@ -253,7 +246,7 @@ mod chat_testing {
         let channel_two_id = chat_helper.channels[1]._id.as_str();
 
         // Subscribe to the first channel with the second user
-        subscribe_to_channel(client, addr, second_token, channel_one_id)
+        subscribe_to_channel(&helper, second_token, channel_one_id)
             .await
             .expect("Failed to subscribe to another users chat channel");
 
@@ -342,7 +335,7 @@ mod chat_testing {
         assert_eq!(user_one_message.atomic_id, 2);
 
         // Get the first channel, assert that its most recent message ID has been updated
-        let updated_first_channel = get_channel_by_id(client, addr, token, channel_one_id)
+        let updated_first_channel = get_channel_by_id(&helper, token, channel_one_id)
             .await
             .expect("Failed to get a chat channel by ID");
         assert_eq!(updated_first_channel.most_recent_message_id, 2);
@@ -387,17 +380,16 @@ mod chat_testing {
     #[tokio::test]
     async fn chat_state() {
         let helper = TestHelper::init().await;
-        let client = &helper.client;
         let addr = &helper.address;
 
-        let chat_helper = ChatHelper::setup_chat(client, addr, 2).await;
+        let chat_helper = ChatHelper::setup_chat(&helper, 2).await;
         let token = chat_helper.tokens[0].as_str();
         let second_token = chat_helper.tokens[1].as_str();
         let channel_one_id = chat_helper.channels[0]._id.as_str();
         let channel_two_id = chat_helper.channels[1]._id.as_str();
 
         // Subscribe to the first channel with the second user
-        subscribe_to_channel(client, addr, second_token, channel_one_id)
+        subscribe_to_channel(&helper, second_token, channel_one_id)
             .await
             .expect("Failed to subscribe to another users chat channel");
 
@@ -514,17 +506,16 @@ mod chat_testing {
         // Rapidly generates 1000 messages, make sure that they are received in the correct order
         // randomize author in the generation, make sure that the broadcasts are received correctly?
         let helper = TestHelper::init().await;
-        let client = &helper.client;
         let addr = &helper.address;
 
-        let chat_helper = ChatHelper::setup_chat(client, addr, 2).await;
+        let chat_helper = ChatHelper::setup_chat(&helper, 2).await;
         let token = chat_helper.tokens[0].as_str();
         let second_token = chat_helper.tokens[1].as_str();
         let user_two_id = chat_helper.users[1].id.as_str();
         let channel_one_id = chat_helper.channels[0]._id.as_str();
 
         // Subscribe to the first channel with the second user
-        subscribe_to_channel(client, addr, second_token, channel_one_id)
+        subscribe_to_channel(&helper, second_token, channel_one_id)
             .await
             .expect("Failed to subscribe to another users chat channel");
 

--- a/homelab_backend/src/testing/games_testing.rs
+++ b/homelab_backend/src/testing/games_testing.rs
@@ -1,17 +1,18 @@
 #[cfg(test)]
 mod games_testing {
     use crate::models::games::validation::{CreateConnectionCategorySchema, CreateConnectionGameSchema};
-
-    use crate::testing::helpers::games_helpers::{create_connections_game, get_game_to_play, list_connections_games, try_connections_solution};
-    use crate::testing::helpers::user_helpers::{create_user, get_user_me};
-    use crate::testing::TestHelper;
+    use crate::testing::{
+        helpers::{
+            games_helpers::{create_connections_game, get_game_to_play, list_connections_games, try_connections_solution},
+            user_helpers::{create_user, get_user_me},
+        },
+        TestHelper,
+    };
     use hyper::StatusCode;
 
     #[tokio::test]
     async fn connections_crud() {
         let helper = TestHelper::init().await;
-        let client = &helper.client;
-        let addr = &helper.address;
 
         let username = "foo";
         let password = "foo";
@@ -20,12 +21,12 @@ mod games_testing {
         let password_two = "second";
 
         // Create users
-        let token = create_user(client, username, password, addr).await.unwrap();
-        let second_token = create_user(client, username_two, password_two, addr).await.unwrap();
+        let token = create_user(&helper, username, password).await.unwrap();
+        let second_token = create_user(&helper, username_two, password_two).await.unwrap();
 
         // Get our user so we have their id
-        let user = get_user_me(client, token.as_str(), addr).await.unwrap();
-        let user_two = get_user_me(client, second_token.as_str(), addr).await.unwrap();
+        let user = get_user_me(&helper, token.as_str()).await.unwrap();
+        let user_two = get_user_me(&helper, second_token.as_str()).await.unwrap();
 
         let connection_categories = [
             CreateConnectionCategorySchema {
@@ -51,14 +52,14 @@ mod games_testing {
             connection_categories: connection_categories.clone(),
             puzzle_name: "Test Puzzle".to_string(),
         };
-        let connection_game = create_connections_game(client, addr, token.as_str(), &data)
+        let connection_game = create_connections_game(&helper, token.as_str(), &data)
             .await
             .expect("Failed to create a connections game");
         assert_eq!(connection_game.author_id, user.id);
         assert_eq!(connection_game.puzzle_name, "Test Puzzle");
 
         // Try to create a connections game with a duplicate slug
-        match create_connections_game(client, addr, token.as_str(), &data).await {
+        match create_connections_game(&helper, token.as_str(), &data).await {
             Ok(_) => panic!("Creating a connections game with a duplicate slug should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -72,7 +73,7 @@ mod games_testing {
             connection_categories: connection_categories.clone(),
             puzzle_name: "Second Test Puzzle".to_string(),
         };
-        let _second_connections_game = create_connections_game(client, addr, token.as_str(), &second_data)
+        let _second_connections_game = create_connections_game(&helper, token.as_str(), &second_data)
             .await
             .expect("Failed to create a connections game");
 
@@ -81,12 +82,12 @@ mod games_testing {
             connection_categories: connection_categories.clone(),
             puzzle_name: "Other User Test Puzzle".to_string(),
         };
-        let other_user_connections_game = create_connections_game(client, addr, second_token.as_str(), &other_user_data)
+        let other_user_connections_game = create_connections_game(&helper, second_token.as_str(), &other_user_data)
             .await
             .expect("Failed to create a connections game");
 
         // List "my" connections games for the first user, there should be two
-        let my_connections_games = list_connections_games(client, addr, token.as_str(), true)
+        let my_connections_games = list_connections_games(&helper, token.as_str(), true)
             .await
             .expect("Failed to get connections games for 'me'");
         assert_eq!(my_connections_games.len(), 2);
@@ -94,14 +95,14 @@ mod games_testing {
         assert_eq!(my_connections_games[1].author_id, user.id);
 
         // List all connections games for other users as the first user, there should be one
-        let other_connections_games = list_connections_games(client, addr, token.as_str(), false)
+        let other_connections_games = list_connections_games(&helper, token.as_str(), false)
             .await
             .expect("Failed to get connections games for other users");
         assert_eq!(other_connections_games.len(), 1);
         assert_eq!(other_connections_games[0].author_id, user_two.id);
 
         // Try to get a game to play that doesn't exist
-        match get_game_to_play(client, addr, token.as_str(), "i-dont-exist").await {
+        match get_game_to_play(&helper, token.as_str(), "i-dont-exist").await {
             Ok(_) => panic!("Getting a connections game with a nonexistent slug should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -111,14 +112,14 @@ mod games_testing {
         }
 
         // Get a connections game to play, this should give us 16 scrambled words
-        let play_game = get_game_to_play(client, addr, token.as_str(), other_user_connections_game.slug.as_str())
+        let play_game = get_game_to_play(&helper, token.as_str(), other_user_connections_game.slug.as_str())
             .await
             .expect("Failed to get a connections game to play");
         assert_eq!(play_game.scrambled_clues.len(), 16);
 
         // Try to solve a row with an incorrect solution
         let bad_guess = ["wrong".to_string(), "wrong".to_string(), "wrong".to_string(), "wrong".to_string()];
-        let bad_guess_response = try_connections_solution(client, addr, token.as_str(), other_user_connections_game.slug.as_str(), bad_guess)
+        let bad_guess_response = try_connections_solution(&helper, token.as_str(), other_user_connections_game.slug.as_str(), bad_guess)
             .await
             .expect("Failed to attempt an incorrect guess for a connections game row");
         assert_eq!(bad_guess_response.row_name, None);
@@ -127,7 +128,7 @@ mod games_testing {
         // Solve a row with a correct solution
         let good_guess = connection_categories[0].category_clues.clone();
         let good_guess_category_name = connection_categories[0].category_name.clone();
-        let good_guess_response = try_connections_solution(client, addr, token.as_str(), other_user_connections_game.slug.as_str(), good_guess)
+        let good_guess_response = try_connections_solution(&helper, token.as_str(), other_user_connections_game.slug.as_str(), good_guess)
             .await
             .expect("Failed to attempt a correct guess for a connections game row");
         assert_eq!(good_guess_response.row_name, Some(good_guess_category_name));

--- a/homelab_backend/src/testing/helpers/chat_helpers.rs
+++ b/homelab_backend/src/testing/helpers/chat_helpers.rs
@@ -4,65 +4,44 @@ use crate::models::chat::{
     packet::{WebSocketError, WebSocketRequest, WebSocketResponse},
     validation::CreateChannelSchema,
 };
-use crate::testing::helpers::{get_request, post_request, put_request};
-use axum::body::Body;
+use crate::testing::{
+    helpers::{get_request, post_request, put_request},
+    TestHelper,
+};
 use axum::http::StatusCode;
 use futures::{SinkExt, StreamExt};
-use hyper_util::client::legacy::connect::HttpConnector;
-use hyper_util::client::legacy::Client;
 use serde_json::json;
-use std::{net::SocketAddr, time::Duration};
+use std::time::Duration;
 use tokio::{net::TcpStream, time::timeout};
 use tokio_tungstenite::{tungstenite, MaybeTlsStream, WebSocketStream};
 
 pub async fn create_chat_channel(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
+    test_helper: &TestHelper,
     token: &str,
     chat_channel: &CreateChannelSchema,
 ) -> Result<ReturnChannel, (StatusCode, String)> {
     let data = json!(chat_channel);
-    post_request(client, "/chat/channels", data, Some(token), addr).await
+    post_request(test_helper, "/chat/channels", data, Some(token)).await
 }
 
-pub async fn subscribe_to_channel(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
-    token: &str,
-    channel_id: &str,
-) -> Result<ReturnChannel, (StatusCode, String)> {
+pub async fn subscribe_to_channel(test_helper: &TestHelper, token: &str, channel_id: &str) -> Result<ReturnChannel, (StatusCode, String)> {
     let data = json!({"channel_id": channel_id});
-    put_request(client, "/chat/channels/subscribe", data, token, addr).await
+    put_request(test_helper, "/chat/channels/subscribe", data, token).await
 }
 
-pub async fn unsubscribe_from_channel(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
-    token: &str,
-    channel_id: &str,
-) -> Result<ReturnChannel, (StatusCode, String)> {
+pub async fn unsubscribe_from_channel(test_helper: &TestHelper, token: &str, channel_id: &str) -> Result<ReturnChannel, (StatusCode, String)> {
     let data = json!({"channel_id": channel_id});
-    put_request(client, "/chat/channels/unsubscribe", data, token, addr).await
+    put_request(test_helper, "/chat/channels/unsubscribe", data, token).await
 }
 
-pub async fn list_channels(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
-    token: &str,
-    query_params: &str,
-) -> Result<Vec<ReturnChannel>, (StatusCode, String)> {
+pub async fn list_channels(test_helper: &TestHelper, token: &str, query_params: &str) -> Result<Vec<ReturnChannel>, (StatusCode, String)> {
     let path = format!("/chat/channels{query_params}");
-    get_request(client, path.as_str(), token, addr).await
+    get_request(test_helper, path.as_str(), token).await
 }
 
-pub async fn get_channel_by_id(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
-    token: &str,
-    channel_id: &str,
-) -> Result<ReturnChannel, (StatusCode, String)> {
+pub async fn get_channel_by_id(test_helper: &TestHelper, token: &str, channel_id: &str) -> Result<ReturnChannel, (StatusCode, String)> {
     let path = format!("/chat/channels/{channel_id}");
-    get_request(client, path.as_str(), token, addr).await
+    get_request(test_helper, path.as_str(), token).await
 }
 
 pub async fn receive_chat_message(socket: &mut WebSocketStream<MaybeTlsStream<TcpStream>>) -> Result<ChatMessage, WebSocketError> {

--- a/homelab_backend/src/testing/helpers/games_helpers.rs
+++ b/homelab_backend/src/testing/helpers/games_helpers.rs
@@ -1,25 +1,22 @@
 use crate::models::games::{validation::CreateConnectionGameSchema, ConnectionGame, MinimalConnectionsGame, PlayConnectionGame, TrySolveRow};
-use crate::testing::helpers::{get_request, post_request, put_request};
-use axum::body::Body;
+use crate::testing::{
+    helpers::{get_request, post_request, put_request},
+    TestHelper,
+};
 use axum::http::StatusCode;
-use hyper_util::client::legacy::connect::HttpConnector;
-use hyper_util::client::legacy::Client;
 use serde_json::json;
-use std::net::SocketAddr;
 
 pub async fn create_connections_game(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
+    test_helper: &TestHelper,
     token: &str,
     connection_game: &CreateConnectionGameSchema,
 ) -> Result<ConnectionGame, (StatusCode, String)> {
     let data = json!(connection_game);
-    post_request(client, "/games/connections", data, Some(token), addr).await
+    post_request(test_helper, "/games/connections", data, Some(token)).await
 }
 
 pub async fn list_connections_games(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
+    test_helper: &TestHelper,
     token: &str,
     my_connections_games: bool,
 ) -> Result<Vec<MinimalConnectionsGame>, (StatusCode, String)> {
@@ -27,27 +24,21 @@ pub async fn list_connections_games(
         true => "/games/connections/mine",
         false => "/games/connections",
     };
-    get_request(client, uri, token, addr).await
+    get_request(test_helper, uri, token).await
 }
 
-pub async fn get_game_to_play(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
-    token: &str,
-    game_slug: &str,
-) -> Result<PlayConnectionGame, (StatusCode, String)> {
+pub async fn get_game_to_play(test_helper: &TestHelper, token: &str, game_slug: &str) -> Result<PlayConnectionGame, (StatusCode, String)> {
     let path = format!("/games/connections/play/{game_slug}");
-    get_request(client, path.as_str(), token, addr).await
+    get_request(test_helper, path.as_str(), token).await
 }
 
 pub async fn try_connections_solution(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
+    test_helper: &TestHelper,
     token: &str,
     game_slug: &str,
     guess: [String; 4],
 ) -> Result<TrySolveRow, (StatusCode, String)> {
     let path = format!("/games/connections/play/{game_slug}/try_solve");
     let data = json!(guess);
-    put_request(client, path.as_str(), data, token, addr).await
+    put_request(test_helper, path.as_str(), data, token).await
 }

--- a/homelab_backend/src/testing/helpers/log_helpers.rs
+++ b/homelab_backend/src/testing/helpers/log_helpers.rs
@@ -1,11 +1,7 @@
 use crate::models::log::Log;
-use crate::testing::helpers::get_request;
-use axum::body::Body;
+use crate::testing::{helpers::get_request, TestHelper};
 use axum::http::StatusCode;
-use hyper_util::client::legacy::connect::HttpConnector;
-use hyper_util::client::legacy::Client;
-use std::net::SocketAddr;
 
-pub async fn get_logs_for_user(client: &Client<HttpConnector, Body>, token: &str, addr: &SocketAddr) -> Result<Vec<Log>, (StatusCode, String)> {
-    get_request(client, "/logs", token, addr).await
+pub async fn get_logs_for_user(test_helper: &TestHelper, token: &str) -> Result<Vec<Log>, (StatusCode, String)> {
+    get_request(test_helper, "/logs", token).await
 }

--- a/homelab_backend/src/testing/helpers/mod.rs
+++ b/homelab_backend/src/testing/helpers/mod.rs
@@ -1,14 +1,11 @@
-use crate::testing::json_bytes;
+use crate::testing::{json_bytes, TestHelper};
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use hyper::body::Bytes;
-use hyper_util::client::legacy::connect::HttpConnector;
-use hyper_util::client::legacy::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{value::Value, Map};
 use std::fmt;
-use std::net::SocketAddr;
 
 pub mod chat_helpers;
 pub mod games_helpers;
@@ -28,19 +25,14 @@ where
     res
 }
 
-pub async fn post_request<T, U>(
-    client: &Client<HttpConnector, Body>,
-    path: &str,
-    data: T,
-    token: Option<&str>,
-    addr: &SocketAddr,
-) -> Result<U, (StatusCode, String)>
+pub async fn post_request<T, U>(test_helper: &TestHelper, path: &str, data: T, token: Option<&str>) -> Result<U, (StatusCode, String)>
 where
     T: Serialize,
     U: for<'a> Deserialize<'a>,
 {
+    let address = &test_helper.address;
     let req_builder = Request::builder()
-        .uri(format!("http://{addr}/api{path}"))
+        .uri(format!("http://{address}/api{path}"))
         .method("POST")
         .header("Host", "localhost")
         .header("Content-Type", "application/json");
@@ -51,7 +43,7 @@ where
     let req = req_builder
         .body(Body::from(json_bytes(data)))
         .expect("Failed to construct a POST request");
-    let res = client.request(req).await.expect("Failed to make a POST request");
+    let res = test_helper.client.request(req).await.expect("Failed to make a POST request");
     match res.status() {
         StatusCode::CREATED => {
             let body = res.into_body().collect().await.unwrap().to_bytes();
@@ -66,19 +58,20 @@ where
     }
 }
 
-pub async fn get_request<U>(client: &Client<HttpConnector, Body>, path: &str, token: &str, addr: &SocketAddr) -> Result<U, (StatusCode, String)>
+pub async fn get_request<U>(test_helper: &TestHelper, path: &str, token: &str) -> Result<U, (StatusCode, String)>
 where
     U: for<'a> Deserialize<'a>,
 {
+    let address = &test_helper.address;
     let req = Request::builder()
-        .uri(format!("http://{addr}/api{path}"))
+        .uri(format!("http://{address}/api{path}"))
         .method("GET")
         .header("Host", "localhost")
         .header("Content-Type", "application/json")
         .header("authorization", token)
         .body(Body::empty())
         .expect("Failed to construct a GET request");
-    let res = client.request(req).await.expect("Failed to make a GET request");
+    let res = test_helper.client.request(req).await.expect("Failed to make a GET request");
     match res.status() {
         StatusCode::OK => {
             let body = res.into_body().collect().await.unwrap().to_bytes();
@@ -93,26 +86,21 @@ where
     }
 }
 
-pub async fn put_request<T, U>(
-    client: &Client<HttpConnector, Body>,
-    path: &str,
-    data: T,
-    token: &str,
-    addr: &SocketAddr,
-) -> Result<U, (StatusCode, String)>
+pub async fn put_request<T, U>(test_helper: &TestHelper, path: &str, data: T, token: &str) -> Result<U, (StatusCode, String)>
 where
     T: Serialize,
     U: for<'a> Deserialize<'a>,
 {
+    let address = &test_helper.address;
     let req = Request::builder()
-        .uri(format!("http://{addr}/api{path}"))
+        .uri(format!("http://{address}/api{path}"))
         .method("PUT")
         .header("Host", "localhost")
         .header("Content-Type", "application/json")
         .header("authorization", token)
         .body(Body::from(json_bytes(data)))
         .expect("Failed to construct a PUT request");
-    let res = client.request(req).await.expect("Failed to make a PUT request");
+    let res = test_helper.client.request(req).await.expect("Failed to make a PUT request");
     match res.status() {
         StatusCode::OK => {
             let body = res.into_body().collect().await.unwrap().to_bytes();
@@ -127,16 +115,17 @@ where
     }
 }
 
-pub async fn delete_request(client: &Client<HttpConnector, Body>, path: &str, token: &str, addr: &SocketAddr) -> Result<(), (StatusCode, String)> {
+pub async fn delete_request(test_helper: &TestHelper, path: &str, token: &str) -> Result<(), (StatusCode, String)> {
+    let address = &test_helper.address;
     let req = Request::builder()
-        .uri(format!("http://{addr}/api{path}"))
+        .uri(format!("http://{address}/api{path}"))
         .method("DELETE")
         .header("Host", "localhost")
         .header("Content-Type", "application/json")
         .header("authorization", token)
         .body(Body::empty())
         .expect("Failed to construct a DELETE request");
-    let res = client.request(req).await.expect("Failed to make a DELETE request");
+    let res = test_helper.client.request(req).await.expect("Failed to make a DELETE request");
     match res.status() {
         StatusCode::OK => Ok(()),
         _ => {

--- a/homelab_backend/src/testing/helpers/reminder_helpers.rs
+++ b/homelab_backend/src/testing/helpers/reminder_helpers.rs
@@ -1,57 +1,39 @@
 use crate::models::reminder::{validation::UpdateReminderSchema, Category, Priority, Reminder};
-use crate::testing::helpers::{delete_request, get_request, post_request, put_request};
-use axum::body::Body;
+use crate::testing::{
+    helpers::{delete_request, get_request, post_request, put_request},
+    TestHelper,
+};
 use axum::http::StatusCode;
-use hyper_util::client::legacy::connect::HttpConnector;
-use hyper_util::client::legacy::Client;
 use serde_json::json;
-use std::net::SocketAddr;
 
-pub async fn create_category(
-    client: &Client<HttpConnector, Body>,
-    token: &str,
-    slug: &str,
-    name: &str,
-    addr: &SocketAddr,
-) -> Result<Category, (StatusCode, String)> {
+pub async fn create_category(test_helper: &TestHelper, token: &str, slug: &str, name: &str) -> Result<Category, (StatusCode, String)> {
     let data = json!({"slug": slug, "name": name});
-    post_request(client, "/reminders/category", data, Some(token), addr).await
+    post_request(test_helper, "/reminders/category", data, Some(token)).await
 }
 
-pub async fn get_categories(client: &Client<HttpConnector, Body>, token: &str, addr: &SocketAddr) -> Result<Vec<Category>, (StatusCode, String)> {
-    get_request(client, "/reminders/category", token, addr).await
+pub async fn get_categories(test_helper: &TestHelper, token: &str) -> Result<Vec<Category>, (StatusCode, String)> {
+    get_request(test_helper, "/reminders/category", token).await
 }
 
-pub async fn delete_category_by_id(
-    client: &Client<HttpConnector, Body>,
-    token: &str,
-    addr: &SocketAddr,
-    category_id: String,
-) -> Result<(), (StatusCode, String)> {
+pub async fn delete_category_by_id(test_helper: &TestHelper, token: &str, category_id: String) -> Result<(), (StatusCode, String)> {
     let path = format!("/reminders/category/{category_id}");
-    delete_request(client, path.as_str(), token, addr).await
+    delete_request(test_helper, path.as_str(), token).await
 }
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create_reminder(
-    client: &Client<HttpConnector, Body>,
+    test_helper: &TestHelper,
     token: &str,
     name: &str,
     description: &str,
     categories: Vec<String>,
     priority: Priority,
-    addr: &SocketAddr,
 ) -> Result<Reminder, (StatusCode, String)> {
     let data = json!({"name": name, "description": description, "categories": categories, "priority": priority});
-    post_request(client, "/reminders", data, Some(token), addr).await
+    post_request(test_helper, "/reminders", data, Some(token)).await
 }
 
-pub async fn list_reminders(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
-    token: &str,
-    categories: Option<Vec<String>>,
-) -> Result<Vec<Reminder>, (StatusCode, String)> {
+pub async fn list_reminders(test_helper: &TestHelper, token: &str, categories: Option<Vec<String>>) -> Result<Vec<Reminder>, (StatusCode, String)> {
     let built_uri = match categories {
         Some(filter_categories) => {
             let params = super::list_to_query_params("categories", filter_categories);
@@ -59,27 +41,21 @@ pub async fn list_reminders(
         }
         None => "/reminders".to_string(),
     };
-    get_request(client, built_uri.as_str(), token, addr).await
+    get_request(test_helper, built_uri.as_str(), token).await
 }
 
 pub async fn update_reminder_helper(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
+    test_helper: &TestHelper,
     token: &str,
     reminder_id: String,
     reminder_updates: UpdateReminderSchema,
 ) -> Result<Reminder, (StatusCode, String)> {
     let path = format!("/reminders/{reminder_id}");
     let data = json!(reminder_updates);
-    put_request(client, path.as_str(), data, token, addr).await
+    put_request(test_helper, path.as_str(), data, token).await
 }
 
-pub async fn delete_reminder_helper(
-    client: &Client<HttpConnector, Body>,
-    addr: &SocketAddr,
-    token: &str,
-    reminder_id: String,
-) -> Result<(), (StatusCode, String)> {
+pub async fn delete_reminder_helper(test_helper: &TestHelper, token: &str, reminder_id: String) -> Result<(), (StatusCode, String)> {
     let path = format!("/reminders/{reminder_id}");
-    delete_request(client, path.as_str(), token, addr).await
+    delete_request(test_helper, path.as_str(), token).await
 }

--- a/homelab_backend/src/testing/helpers/user_helpers.rs
+++ b/homelab_backend/src/testing/helpers/user_helpers.rs
@@ -1,45 +1,27 @@
 use crate::models::user::{validation::UpdateUserSchema, ReturnUser};
 use crate::testing::helpers::{delete_request, get_request, post_request, put_request};
-use axum::body::Body;
+use crate::testing::TestHelper;
 use axum::http::StatusCode;
-use hyper_util::client::legacy::connect::HttpConnector;
-use hyper_util::client::legacy::Client;
 use serde_json::json;
-use std::net::SocketAddr;
 
-pub async fn create_user(
-    client: &Client<HttpConnector, Body>,
-    username: &str,
-    password: &str,
-    addr: &SocketAddr,
-) -> Result<String, (StatusCode, String)> {
+pub async fn create_user(test_helper: &TestHelper, username: &str, password: &str) -> Result<String, (StatusCode, String)> {
     let data = json!({"username": username, "password": password});
-    post_request(client, "/users", data, None, addr).await
+    post_request(test_helper, "/users", data, None).await
 }
 
-pub async fn auth_user(
-    client: &Client<HttpConnector, Body>,
-    username: &str,
-    password: &str,
-    addr: &SocketAddr,
-) -> Result<String, (StatusCode, String)> {
+pub async fn auth_user(test_helper: &TestHelper, username: &str, password: &str) -> Result<String, (StatusCode, String)> {
     let data = json!({"username": username, "password": password});
-    post_request(client, "/users/auth", data, None, addr).await
+    post_request(test_helper, "/users/auth", data, None).await
 }
 
-pub async fn update_user(
-    client: &Client<HttpConnector, Body>,
-    token: &str,
-    addr: &SocketAddr,
-    update_data: UpdateUserSchema,
-) -> Result<ReturnUser, (StatusCode, String)> {
-    put_request(client, "/users/me", update_data, token, addr).await
+pub async fn update_user(test_helper: &TestHelper, token: &str, update_data: UpdateUserSchema) -> Result<ReturnUser, (StatusCode, String)> {
+    put_request(test_helper, "/users/me", update_data, token).await
 }
 
-pub async fn get_user_me(client: &Client<HttpConnector, Body>, token: &str, addr: &SocketAddr) -> Result<ReturnUser, (StatusCode, String)> {
-    get_request(client, "/users/me", token, addr).await
+pub async fn get_user_me(test_helper: &TestHelper, token: &str) -> Result<ReturnUser, (StatusCode, String)> {
+    get_request(test_helper, "/users/me", token).await
 }
 
-pub async fn delete_user_me(client: &Client<HttpConnector, Body>, token: &str, addr: &SocketAddr) -> Result<(), (StatusCode, String)> {
-    delete_request(client, "/users/me", token, addr).await
+pub async fn delete_user_me(test_helper: &TestHelper, token: &str) -> Result<(), (StatusCode, String)> {
+    delete_request(test_helper, "/users/me", token).await
 }

--- a/homelab_backend/src/testing/log_testing.rs
+++ b/homelab_backend/src/testing/log_testing.rs
@@ -1,8 +1,12 @@
 #[cfg(test)]
 mod log_testing {
-    use crate::testing::helpers::log_helpers::get_logs_for_user;
-    use crate::testing::helpers::user_helpers::{auth_user, create_user, get_user_me};
-    use crate::testing::TestHelper;
+    use crate::testing::{
+        helpers::{
+            log_helpers::get_logs_for_user,
+            user_helpers::{auth_user, create_user, get_user_me},
+        },
+        TestHelper,
+    };
 
     #[tokio::test]
     async fn log_generation() {
@@ -15,16 +19,12 @@ mod log_testing {
         let user_two_password = "two";
 
         // Create a user
-        create_user(&helper.client, user_one_username, user_one_password, &helper.address)
-            .await
-            .unwrap();
+        create_user(&helper, user_one_username, user_one_password).await.unwrap();
 
         // Generate logs with our user
-        let token = auth_user(&helper.client, user_one_username, user_one_password, &helper.address)
-            .await
-            .unwrap();
-        let user = get_user_me(&helper.client, token.as_str(), &helper.address).await.unwrap();
-        get_user_me(&helper.client, token.as_str(), &helper.address).await.unwrap();
+        let token = auth_user(&helper, user_one_username, user_one_password).await.unwrap();
+        let user = get_user_me(&helper, token.as_str()).await.unwrap();
+        get_user_me(&helper, token.as_str()).await.unwrap();
 
         // Run the log generation task manually rather than waiting for it
         {
@@ -37,7 +37,7 @@ mod log_testing {
         }
 
         // Get logs
-        let logs = get_logs_for_user(&helper.client, token.as_str(), &helper.address).await.unwrap();
+        let logs = get_logs_for_user(&helper, token.as_str()).await.unwrap();
 
         // Verify that the logs look correct
         assert_eq!(logs.len(), 2);
@@ -46,15 +46,11 @@ mod log_testing {
         assert_eq!(logs[0].user_id, user.id);
 
         // Create a second user
-        create_user(&helper.client, user_two_username, user_two_password, &helper.address)
-            .await
-            .unwrap();
+        create_user(&helper, user_two_username, user_two_password).await.unwrap();
 
         // Generate logs with the second user
-        let token_two = auth_user(&helper.client, user_two_username, user_two_password, &helper.address)
-            .await
-            .unwrap();
-        let user_two = get_user_me(&helper.client, token_two.as_str(), &helper.address).await.unwrap();
+        let token_two = auth_user(&helper, user_two_username, user_two_password).await.unwrap();
+        let user_two = get_user_me(&helper, token_two.as_str()).await.unwrap();
 
         // Run the log generation task manually rather than waiting for it
         {
@@ -67,7 +63,7 @@ mod log_testing {
         }
 
         // Get logs for the second user
-        let logs = get_logs_for_user(&helper.client, token_two.as_str(), &helper.address).await.unwrap();
+        let logs = get_logs_for_user(&helper, token_two.as_str()).await.unwrap();
 
         // Verify that the logs look correct
         assert_eq!(logs.len(), 1);

--- a/homelab_backend/src/testing/mod.rs
+++ b/homelab_backend/src/testing/mod.rs
@@ -7,22 +7,14 @@ mod log_testing;
 mod reminder_testing;
 mod user_testing;
 
-use crate::{
-    app::generate_app,
-    db::{db_setup, MongoModel},
-    models::{
-        chat::{chat_channel::ChatChannel, message::ChatMessage},
-        games::ConnectionGame,
-        log::Log,
-        reminder::{Category, Reminder},
-        user::User,
-    },
-    tasks::task_manager::TaskManager,
-};
+use crate::{app::generate_app, db::db_setup, tasks::task_manager::TaskManager};
 use axum::body::Body;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
-use mongodb::{bson::doc, Collection, Database};
+use mongodb::{
+    bson::{doc, Document},
+    Collection, Database,
+};
 use serde::Serialize;
 use std::{
     net::SocketAddr,
@@ -53,7 +45,7 @@ impl TestHelper {
                 .await
                 .unwrap()
         });
-        let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new()).build_http();
+        let client = Client::builder(hyper_util::rt::TokioExecutor::new()).build_http();
         let helper = Self {
             client,
             address,
@@ -65,28 +57,17 @@ impl TestHelper {
     }
 
     pub async fn wipe_database(&self) {
-        // TODO: This is not sustainable, what if 100 collections are added?
-
-        let user_collection: Collection<User> = self.database.collection(User::collection_name());
-        let _res = user_collection.delete_many(doc! {}).await;
-
-        let log_collection: Collection<Log> = self.database.collection(Log::collection_name());
-        let _res = log_collection.delete_many(doc! {}).await;
-
-        let categories_collection: Collection<Category> = self.database.collection(Category::collection_name());
-        let _res = categories_collection.delete_many(doc! {}).await;
-
-        let reminders_collection: Collection<Reminder> = self.database.collection(Reminder::collection_name());
-        let _res = reminders_collection.delete_many(doc! {}).await;
-
-        let games_collection: Collection<ConnectionGame> = self.database.collection(ConnectionGame::collection_name());
-        let _res = games_collection.delete_many(doc! {}).await;
-
-        let chat_channels_collection: Collection<ChatChannel> = self.database.collection(ChatChannel::collection_name());
-        let _res = chat_channels_collection.delete_many(doc! {}).await;
-
-        let chat_messages_collection: Collection<ChatMessage> = self.database.collection(ChatMessage::collection_name());
-        let _res = chat_messages_collection.delete_many(doc! {}).await;
+        // Get all collections in the test database and wipe each of them
+        let collections: Vec<String> = self
+            .database
+            .list_collection_names()
+            .await
+            .expect("Failed to get collection data while wiping database during test setup");
+        for collection_name in collections {
+            let collection: Collection<Document> = self.database.collection(collection_name.as_str());
+            // An empty filter doc will grab all documents in the collection
+            let _res = collection.delete_many(doc! {}).await;
+        }
     }
 }
 

--- a/homelab_backend/src/testing/reminder_testing.rs
+++ b/homelab_backend/src/testing/reminder_testing.rs
@@ -1,36 +1,39 @@
 #[cfg(test)]
 mod reminder_testing {
     use crate::models::reminder::{validation::UpdateReminderSchema, Priority, Reminder};
-    use crate::testing::helpers::put_request;
-    use crate::testing::helpers::reminder_helpers::{
-        create_category, create_reminder, delete_category_by_id, delete_reminder_helper, get_categories, list_reminders, update_reminder_helper,
+    use crate::testing::{
+        helpers::{
+            put_request,
+            reminder_helpers::{
+                create_category, create_reminder, delete_category_by_id, delete_reminder_helper, get_categories, list_reminders,
+                update_reminder_helper,
+            },
+            user_helpers::{create_user, get_user_me},
+        },
+        TestHelper,
     };
-    use crate::testing::helpers::user_helpers::{create_user, get_user_me};
-    use crate::testing::TestHelper;
     use hyper::StatusCode;
     use serde_json::json;
 
     #[tokio::test]
     async fn reminder_crud() {
         let helper = TestHelper::init().await;
-        let client = &helper.client;
-        let addr = &helper.address;
 
         let username = "foo";
         let password = "foo";
 
         // Create a user
-        let token = create_user(client, username, password, addr).await.unwrap();
+        let token = create_user(&helper, username, password).await.unwrap();
 
         // Get our user so we have their id
-        let user = get_user_me(client, token.as_str(), addr).await.unwrap();
+        let user = get_user_me(&helper, token.as_str()).await.unwrap();
 
         // Create two categories
-        let created_category = create_category(client, token.as_str(), "test_category", "test_category", addr)
+        let created_category = create_category(&helper, token.as_str(), "test_category", "test_category")
             .await
             .expect("Failed to create a new category");
 
-        let second_category = create_category(client, token.as_str(), "second_category", "second_category", addr)
+        let second_category = create_category(&helper, token.as_str(), "second_category", "second_category")
             .await
             .expect("Failed to create a second new category");
 
@@ -41,13 +44,12 @@ mod reminder_testing {
         let reminder_name = "test_reminder";
         let reminder_categories = vec![created_category.id.clone(), second_category.id.clone()];
         let created_reminder = create_reminder(
-            client,
+            &helper,
             token.as_str(),
             reminder_name,
             "test_reminder",
             reminder_categories.clone(),
             Priority::Medium,
-            addr,
         )
         .await
         .expect("Failed to create a new reminder");
@@ -58,7 +60,7 @@ mod reminder_testing {
         assert_eq!(created_reminder.user_id, user.id);
 
         // Try to delete a category used by a reminder
-        match delete_category_by_id(client, token.as_str(), addr, created_category.id.clone()).await {
+        match delete_category_by_id(&helper, token.as_str(), created_category.id.clone()).await {
             Ok(_) => panic!("Should not be able to delete a category linked to a reminder"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -69,19 +71,18 @@ mod reminder_testing {
 
         // Create a second reminder which only uses the first category
         let second_reminder = create_reminder(
-            client,
+            &helper,
             token.as_str(),
             "second_reminder",
             "second test reminder",
             vec![created_category.id.clone()],
             Priority::Medium,
-            addr,
         )
         .await
         .expect("Failed to create a second reminder");
 
         // List all reminders
-        let reminders = list_reminders(client, addr, token.as_str(), None)
+        let reminders = list_reminders(&helper, token.as_str(), None)
             .await
             .expect("Failed to get a list of reminders");
         assert_eq!(reminders.len(), 2);
@@ -89,7 +90,7 @@ mod reminder_testing {
         assert_eq!(reminders[1], second_reminder);
 
         // List all reminders which use the first category
-        let list_filter_to_first_category = list_reminders(client, addr, token.as_str(), Some(vec![created_category.id.clone()]))
+        let list_filter_to_first_category = list_reminders(&helper, token.as_str(), Some(vec![created_category.id.clone()]))
             .await
             .expect("Failed to get a list of reminders filtered to one category");
         assert_eq!(list_filter_to_first_category.len(), 2);
@@ -97,14 +98,14 @@ mod reminder_testing {
         assert_eq!(list_filter_to_first_category[1], second_reminder);
 
         // List all reminders which use the second category
-        let list_filter_to_second_category = list_reminders(client, addr, token.as_str(), Some(vec![second_category.id.clone()]))
+        let list_filter_to_second_category = list_reminders(&helper, token.as_str(), Some(vec![second_category.id.clone()]))
             .await
             .expect("Failed to get a list of reminders filtered to one category");
         assert_eq!(list_filter_to_second_category.len(), 1);
         assert_eq!(list_filter_to_second_category[0], created_reminder);
 
         // List all reminders which use a category that doesn't exist
-        let list_filter_to_unused_category = list_reminders(client, addr, token.as_str(), Some(vec!["aaaaaaaaaaaaaaaaaaaaaaaa".to_string()]))
+        let list_filter_to_unused_category = list_reminders(&helper, token.as_str(), Some(vec!["aaaaaaaaaaaaaaaaaaaaaaaa".to_string()]))
             .await
             .expect("Failed to get a list of reminders filtered to a category that does not exist");
         assert_eq!(list_filter_to_unused_category.len(), 0);
@@ -116,7 +117,7 @@ mod reminder_testing {
             categories: None,
             priority: None,
         };
-        match update_reminder_helper(client, addr, token.as_str(), reminders[0].id.clone(), bad_update_data).await {
+        match update_reminder_helper(&helper, token.as_str(), reminders[0].id.clone(), bad_update_data).await {
             Ok(_) => panic!("Updating a category with no update data should fail."),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -132,7 +133,7 @@ mod reminder_testing {
             categories: None,
             priority: None,
         };
-        let update_reminder_res = update_reminder_helper(client, addr, token.as_str(), reminders[0].id.clone(), update_data)
+        let update_reminder_res = update_reminder_helper(&helper, token.as_str(), reminders[0].id.clone(), update_data)
             .await
             .expect("Failed to update a reminder");
         assert_eq!(update_reminder_res.name.as_str(), reminder_name);
@@ -145,7 +146,7 @@ mod reminder_testing {
             categories: Some(vec![created_category.id.clone()]),
             priority: None,
         };
-        let second_update = update_reminder_helper(client, addr, token.as_str(), reminders[0].id.clone(), multiple_updates)
+        let second_update = update_reminder_helper(&helper, token.as_str(), reminders[0].id.clone(), multiple_updates)
             .await
             .expect("Failed to update a reminder");
         assert_eq!(second_update.categories, vec![created_category.id.clone()]);
@@ -158,7 +159,7 @@ mod reminder_testing {
             categories: None,
             priority: Some(Priority::VeryHigh),
         };
-        let update_priority = update_reminder_helper(client, addr, token.as_str(), reminders[0].id.clone(), priority_update)
+        let update_priority = update_reminder_helper(&helper, token.as_str(), reminders[0].id.clone(), priority_update)
             .await
             .expect("Failed to update a reminders priority");
         assert_eq!(update_priority.priority, Priority::VeryHigh);
@@ -167,7 +168,7 @@ mod reminder_testing {
         let reminder_id = reminders[0].id.clone();
         let update_path = format!("/reminders/{reminder_id}");
         let bad_update_data = json!({"bad_field": 5});
-        match put_request::<serde_json::Value, Reminder>(client, update_path.as_str(), bad_update_data, token.as_str(), addr).await {
+        match put_request::<serde_json::Value, Reminder>(&helper, update_path.as_str(), bad_update_data, token.as_str()).await {
             Ok(_) => panic!("Updating a reminder with invalid data should fail."),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -177,12 +178,12 @@ mod reminder_testing {
         };
 
         // Delete a reminder
-        delete_reminder_helper(client, addr, token.as_str(), reminders[0].id.clone())
+        delete_reminder_helper(&helper, token.as_str(), reminders[0].id.clone())
             .await
             .expect("Failed to delete a reminder");
 
         // List reminders, there should only be one now
-        let reminders_again = list_reminders(client, addr, token.as_str(), None)
+        let reminders_again = list_reminders(&helper, token.as_str(), None)
             .await
             .expect("Failed to get a list of reminders");
         assert_eq!(reminders_again.len(), 1);
@@ -191,21 +192,19 @@ mod reminder_testing {
     #[tokio::test]
     async fn category_crud() {
         let helper = TestHelper::init().await;
-        let client = &helper.client;
-        let addr = &helper.address;
 
         let username = "foo";
         let password = "foo";
 
         // Create a user
-        let token = create_user(client, username, password, addr).await.unwrap();
+        let token = create_user(&helper, username, password).await.unwrap();
 
         // Get our user so we have their id
-        let user = get_user_me(client, token.as_str(), addr).await.unwrap();
+        let user = get_user_me(&helper, token.as_str()).await.unwrap();
 
         // Create a category
         let category_slug = "test_category";
-        let created_category = create_category(client, token.as_str(), category_slug, category_slug, addr)
+        let created_category = create_category(&helper, token.as_str(), category_slug, category_slug)
             .await
             .expect("Failed to create a new category");
         assert_eq!(created_category.slug.as_str(), category_slug);
@@ -213,7 +212,7 @@ mod reminder_testing {
         assert_eq!(created_category.user_id, user.id);
 
         // Try to create a category that already exists
-        match create_category(client, token.as_str(), category_slug, category_slug, addr).await {
+        match create_category(&helper, token.as_str(), category_slug, category_slug).await {
             Ok(_) => panic!("Creating a category with a duplicate slug should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,
@@ -224,12 +223,12 @@ mod reminder_testing {
 
         // Create a second category
         let second_category_slug = "second_category";
-        create_category(client, token.as_str(), second_category_slug, second_category_slug, addr)
+        create_category(&helper, token.as_str(), second_category_slug, second_category_slug)
             .await
             .expect("Failed to create a new category");
 
         // Get all categories
-        let categories = get_categories(&helper.client, token.as_str(), &helper.address)
+        let categories = get_categories(&helper, token.as_str())
             .await
             .expect("Failed to get categories for a user");
         assert_eq!(categories.len(), 2);
@@ -237,12 +236,12 @@ mod reminder_testing {
         assert_eq!(categories[1].user_id, user.id);
 
         // Delete a category
-        delete_category_by_id(client, token.as_str(), addr, categories[1].id.clone())
+        delete_category_by_id(&helper, token.as_str(), categories[1].id.clone())
             .await
             .expect("Failed to delete category by id");
 
         // Try to delete a category that was already deleted
-        match delete_category_by_id(client, token.as_str(), addr, categories[1].id.clone()).await {
+        match delete_category_by_id(&helper, token.as_str(), categories[1].id.clone()).await {
             Ok(_) => panic!("Deleting a category that does not exist should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,

--- a/homelab_backend/src/testing/user_testing.rs
+++ b/homelab_backend/src/testing/user_testing.rs
@@ -8,17 +8,15 @@ mod user_testing {
     #[tokio::test]
     async fn user_crud() {
         let helper = TestHelper::init().await;
-        let client = &helper.client;
-        let addr = &helper.address;
 
         let username = "foo";
         let password = "bar";
 
         // Create a new user
-        create_user(client, username, password, addr).await.expect("Failed to create a new user");
+        create_user(&helper, username, password).await.expect("Failed to create a new user");
 
         // Try to create a user where the username is already taken
-        match create_user(client, username, password, addr).await {
+        match create_user(&helper, username, password).await {
             Ok(_) => panic!("Creating a user where the username is already taken should error"),
             Err((status_code, err_msg)) => match status_code {
                 StatusCode::BAD_REQUEST => {
@@ -29,13 +27,13 @@ mod user_testing {
         }
 
         // Auth with the new user
-        let token = match auth_user(client, username, password, addr).await {
+        let token = match auth_user(&helper, username, password).await {
             Ok(t) => t,
             Err((_status_code, msg)) => panic!("{}", msg),
         };
 
         // get user
-        let user_me = get_user_me(client, token.as_str(), addr).await.unwrap();
+        let user_me = get_user_me(&helper, token.as_str()).await.unwrap();
         assert_eq!(user_me.username.as_str(), username);
 
         // Update
@@ -46,14 +44,14 @@ mod user_testing {
             let new_password = "user_two_new";
 
             // Create a second user to test username collision
-            let user_two_token = create_user(client, user_two_username, user_two_password, addr).await.unwrap();
+            let user_two_token = create_user(&helper, user_two_username, user_two_password).await.unwrap();
 
             // Try to update the username to one already in use
             let bad_update_data = UpdateUserSchema {
                 username: Some(username.to_owned()),
                 password: None,
             };
-            match update_user(client, user_two_token.as_str(), addr, bad_update_data).await {
+            match update_user(&helper, user_two_token.as_str(), bad_update_data).await {
                 Ok(_) => panic!("Updating a username to one already in use should fail"),
                 Err((status_code, _msg)) => assert_eq!(
                     status_code,
@@ -67,7 +65,7 @@ mod user_testing {
                 username: Some(new_username.to_owned()),
                 password: Some(new_password.to_owned()),
             };
-            let updated_user = update_user(client, user_two_token.as_str(), addr, update_data)
+            let updated_user = update_user(&helper, user_two_token.as_str(), update_data)
                 .await
                 .expect("Failed to update a users username and password");
             assert_eq!(
@@ -78,7 +76,7 @@ mod user_testing {
 
             // TODO: https://github.com/kyleoneill/pat/issues/48
             // // Try to make a request with user two's existing token, which should have been kicked
-            // match get_user_me(client, user_two_token.as_str(), addr).await {
+            // match get_user_me(&helper, user_two_token.as_str()).await {
             //     Ok(_) => panic!("User token should have been kicked after their password was changed"),
             //     Err((status_code, _msg)) => assert_eq!(
             //         status_code,
@@ -88,16 +86,16 @@ mod user_testing {
             // }
 
             // Auth with the new password, verify the token words
-            let new_token = auth_user(client, new_username, new_password, addr)
+            let new_token = auth_user(&helper, new_username, new_password)
                 .await
                 .expect("Failed to auth with a new password");
-            get_user_me(client, new_token.as_str(), addr)
+            get_user_me(&helper, new_token.as_str())
                 .await
                 .expect("Failed to use an auth token generated after password has been changed");
         }
 
         // delete user
-        match delete_user_me(client, token.as_str(), addr).await {
+        match delete_user_me(&helper, token.as_str()).await {
             Ok(_) => (),
             Err(_e) => panic!("Failed to delete a user with the /me endpoint"),
         }
@@ -105,7 +103,7 @@ mod user_testing {
         // Try to get the user, verify that they were deleted and that their token does not work
         // TODO: Should be getting the user as admin so we know the request is valid and there is
         //       a better confirmation that the user is deleted
-        match get_user_me(client, token.as_str(), addr).await {
+        match get_user_me(&helper, token.as_str()).await {
             Ok(_) => panic!("Deleting a user and then trying to get their account should fail"),
             Err((status_code, _msg)) => assert_eq!(
                 status_code,


### PR DESCRIPTION
Refactor test helpers to just take a `TestHelper` struct rather than its constituent parts as arguments. Also fix a bug where custom mongo errors cause 500s.